### PR TITLE
Fixed invalid comment syntax

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -2,7 +2,7 @@ CREATE TABLE schema_version (
     version INTEGER
 );
 
-# keep in sync with constants.py
+-- keep in sync with constants.py
 INSERT INTO schema_version (version) VALUES (1);
 
 CREATE TABLE scrobble (


### PR DESCRIPTION
Initial database creation fails with:
```
Traceback (most recent call last):
  File "/home/zerodogg/tidal-utils/lastfm-listenbrainz-sync/./fetch_scrobbles.py", line 21, in <module>
    db_con = get_db_con()
             ^^^^^^^^^^^^
  File "/home/zerodogg/tidal-utils/lastfm-listenbrainz-sync/utils.py", line 54, in get_db_con
    cur.executescript(fp.read())
sqlite3.OperationalError: unrecognized token: "#"
```

This is because a `#` is used for a comment in `schema.sql`, causing sqlite to throw a syntax error. This replaces it with the correct `--`.