### PR TITLE
last.fm api key from config.ini

### DIFF
--- a/config.dist.ini
+++ b/config.dist.ini
@@ -1,5 +1,8 @@
 [lastfm]
 username=your_lastfm_username
+api_key=your_lastfm_api_key
+# Get your lastfm api key from
+# https://www.last.fm/api/account/create
 
 # The date on which the script will start fetching
 # scrobbles from Last.fm, in ISO format. You should

--- a/config.py
+++ b/config.py
@@ -1,11 +1,18 @@
 import configparser
+import sys
 
 _config = configparser.ConfigParser()
 _config.read('config.ini')
 
 _lastfm = _config['lastfm']
 lastfm_username = _lastfm['username']
+lastfm_api_key = _lastfm['api_key']
 lastfm_first_scrobble_date = _lastfm['first_scrobble_date']
+
+if lastfm_api_key == 'your_lastfm_api_key' or not lastfm_api_key.strip():
+    print('Error: You must enter your Last.fm API key in config.ini')
+    print('Get it from: https://www.last.fm/api/account/create')
+    sys.exit(1)
 
 _listenbrainz = _config['listenbrainz']
 listenbrainz_user_token = _listenbrainz['user_token']

--- a/constants.py
+++ b/constants.py
@@ -1,15 +1,11 @@
-import base64
 import os
-
 
 _cwd = os.getcwd()
 
-_EGGPLANT = b'ZjZkN2YyMWMwMDQwZjhjYjkxOTljNTQ0ZmFmM2I5ZWE='
-BABA_GHANOUJ = base64.b64decode(_EGGPLANT).decode('ascii')
 LAST_SUBMITTED_LISTEN_FILE = os.path.join(_cwd, 'last_submitted_listen')
 LASTFM_API_ROOT = 'http://ws.audioscrobbler.com/2.0/'
 LASTFM_DATA_ROOT = os.path.join(_cwd, 'lastfm_data')
-LATEST_SCHEMA_VERSION = 1  # keep in sync with schema.sql
+LATEST_SCHEMA_VERSION = 1
 LISTENBRAINZ_API_ROOT = 'https://api.listenbrainz.org/1/'
 SCROBBLE_FIXES_ROOT = os.path.join(_cwd, 'scrobble_fixes')
 SCROBBLES_DB_FILE = os.path.join(_cwd, 'scrobbles.db')

--- a/fetch_scrobbles.py
+++ b/fetch_scrobbles.py
@@ -6,12 +6,11 @@ import json
 import math
 import os
 from constants import (
-    BABA_GHANOUJ,
     LASTFM_API_ROOT,
     LASTFM_DATA_ROOT,
     SCROBBLE_FIXES_ROOT
 )
-from config import lastfm_first_scrobble_date, lastfm_username
+from config import lastfm_first_scrobble_date, lastfm_username, lastfm_api_key
 from utils import (
     cmp_strings,
     epoch_range_for_date,
@@ -42,7 +41,7 @@ def fetch_scrobbles_for_date(db_con, date_obj, fetched_at):
         '&from=' + str(from_uts) +
         '&to=' + str(to_uts) +
         '&limit=200' +
-        '&api_key=' + BABA_GHANOUJ +
+        '&api_key=' + lastfm_api_key +
         '&format=json'
     )
     current_page = 1


### PR DESCRIPTION
instead of hardcoding it

this fixes a lot of problems, since the hardcoded one doesn't work right now.