### PR TITLE
make epoch_range_for_date UTC-aware

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -15,7 +15,10 @@ from constants import (
 
 def epoch_range_for_date(date_obj):
     # in the lastfm api, "from" is inclusive and "to" is exclusive
-    dt1 = datetime.datetime.combine(date_obj, datetime.datetime.min.time())
+    dt1 = datetime.datetime(
+        date_obj.year, date_obj.month, date_obj.day,
+        tzinfo=datetime.timezone.utc
+    )
     dt2 = dt1 + datetime.timedelta(days=1)
     return (int(dt1.timestamp()), int(dt2.timestamp()))
 


### PR DESCRIPTION
noticed too late that if the local system timezone is not UTC, `datetime.datetime.combine()` produces naive datetimes that are interpreted in the local timezone, causing the "from"/"to" epoch values to be offset by the UTC difference.
